### PR TITLE
mock modules without tricking sphinx

### DIFF
--- a/docs/admissible_reduction.rst
+++ b/docs/admissible_reduction.rst
@@ -1,6 +1,1 @@
-
-.. toctree::
-
-.. automodule::
-   mclf.semistable_reduction.admissible_reduction
-   :members:
+.. automodule:: mclf.semistable_reduction.admissible_reduction

--- a/docs/affinoid_domain.rst
+++ b/docs/affinoid_domain.rst
@@ -1,6 +1,1 @@
-
-.. toctree::
-
-.. automodule::
-   mclf.berkovich.affinoid_domain
-   :members:
+.. automodule:: mclf.berkovich.affinoid_domain

--- a/docs/berkovich_line.rst
+++ b/docs/berkovich_line.rst
@@ -1,6 +1,1 @@
-
-.. toctree::
-
-.. automodule::
-   mclf.berkovich.berkovich_line
-   :members:
+.. automodule:: mclf.berkovich.berkovich_line

--- a/docs/berkovich_trees.rst
+++ b/docs/berkovich_trees.rst
@@ -1,6 +1,1 @@
-
-.. toctree::
-
-.. automodule::
-   mclf.berkovich.berkovich_trees
-   :members:
+.. automodule:: mclf.berkovich.berkovich_trees

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -336,15 +336,34 @@ epub_exclude_files = ['search.html']
 #epub_use_index = True
 
 # -- mock things from sage that we won't have on readthedocs --
+autodoc_default_flags = ["members", "show-inheritance"]
+
 try:
     import sage
 except ImportError:
     from unittest.mock import MagicMock
-    
+
+    class BaseClass: pass
+
+    class Infinity:
+        def __repr__(self): return "∞"
+
+    class ReprMock(MagicMock):
+        def __repr__(self):
+            raise NotImplemented("Do not use mocked objects, i.e., things coming from Sage as default arguments. Caching in Sage might produce surprising side effects, and it breaks printing of these things in the generated readthedocs documentation.")
+
     class Mock(MagicMock):
         @classmethod
         def __getattr__(cls, name):
-                return MagicMock()
-    
-    MOCK_MODULES = ['sage', 'sage.all', 'sage.geometry.newton_polygon', 'sage.rings.valuation.limit_valuation', 'sage.rings.valuation.valuation']
-    sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+            if name == "SageObject":
+                # Mock SageObject differently. Sphinx refuses to document
+                # things that inherit from a mock.
+                return BaseClass
+            if name == "Infinity":
+                return Infinity()
+            return ReprMock()
+
+    MOCK_MODULES = ['sage.all', 'sage.geometry.newton_polygon']
+    # import works differently than "from … import". Therefore we need to mock all parent modules for monkey.py
+    MONKEY_MOCK_MODULES = ['sage', 'sage.rings', 'sage.rings.valuation', 'sage.rings.valuation.valuation', 'sage.rings.valuation.limit_valuation']
+    sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES + MONKEY_MOCK_MODULES)

--- a/docs/fake_padic_completions.rst
+++ b/docs/fake_padic_completions.rst
@@ -1,6 +1,1 @@
-
-.. toctree::
-
-.. automodule::
-   mclf.padic_extensions.fake_padic_completions
-   :members:
+.. automodule:: mclf.padic_extensions.fake_padic_completions

--- a/docs/fake_padic_extensions.rst
+++ b/docs/fake_padic_extensions.rst
@@ -1,6 +1,1 @@
-
-.. toctree::
-
-.. automodule::
-   mclf.padic_extensions.fake_padic_extensions
-   :members:
+.. automodule:: mclf.padic_extensions.fake_padic_extensions

--- a/docs/morphisms_of_smooth_projective_curves.rst
+++ b/docs/morphisms_of_smooth_projective_curves.rst
@@ -1,6 +1,1 @@
-
-.. toctree::
-
-.. automodule::
-   mclf.curves.morphisms_of_smooth_projective_curves
-   :members:
+.. automodule:: mclf.curves.morphisms_of_smooth_projective_curves

--- a/docs/reduction_trees.rst
+++ b/docs/reduction_trees.rst
@@ -1,6 +1,1 @@
-
-.. toctree::
-
-.. automodule::
-   mclf.semistable_reduction.reduction_trees
-   :members:
+.. automodule:: mclf.semistable_reduction.reduction_trees

--- a/docs/smooth_projective_curves.rst
+++ b/docs/smooth_projective_curves.rst
@@ -1,6 +1,1 @@
-
-.. toctree::
-
-.. automodule::
-   mclf.curves.smooth_projective_curves
-   :members:
+.. automodule:: mclf.curves.smooth_projective_curves

--- a/docs/superell.rst
+++ b/docs/superell.rst
@@ -1,6 +1,1 @@
-
-.. toctree::
-
-.. automodule::
-   mclf.semistable_reduction.superell
-   :members:
+.. automodule:: mclf.semistable_reduction.superell

--- a/docs/superp.rst
+++ b/docs/superp.rst
@@ -1,6 +1,1 @@
-
-.. toctree::
-
-.. automodule::
-   mclf.semistable_reduction.superp
-   :members:
+.. automodule:: mclf.semistable_reduction.superp

--- a/docs/type_V_points.rst
+++ b/docs/type_V_points.rst
@@ -1,6 +1,1 @@
-
-.. toctree::
-
-.. automodule::
-   mclf.berkovich.type_V_points
-   :members:
+.. automodule:: mclf.berkovich.type_V_points

--- a/docs/weak_padic_galois_extensions
+++ b/docs/weak_padic_galois_extensions
@@ -1,6 +1,0 @@
-
-.. toctree::
-
-.. automodule::
-   mclf.padic_extensions.weak_padic_galois_extensions
-   :members:

--- a/docs/weak_padic_galois_extensions.rst
+++ b/docs/weak_padic_galois_extensions.rst
@@ -1,6 +1,1 @@
-
-.. toctree::
-
-.. automodule::
-   mclf.padic_extensions.weak_padic_galois_extensions
-   :members:
+.. automodule:: mclf.padic_extensions.weak_padic_galois_extensions

--- a/mclf/padic_extensions/weak_padic_galois_extensions.py
+++ b/mclf/padic_extensions/weak_padic_galois_extensions.py
@@ -103,7 +103,6 @@ from mclf.padic_extensions.fake_padic_completions import FakepAdicCompletion
 from mclf.padic_extensions.fake_padic_extensions import FakepAdicExtension
 from mclf.padic_extensions.slope_factors import slope_factors
 
-
 class WeakPadicGaloisExtension(FakepAdicExtension):
     r"""
     Return the weak p-adic splitting field of a polynomial.
@@ -124,8 +123,8 @@ class WeakPadicGaloisExtension(FakepAdicExtension):
     and ``minimal ramification`` has to be prime to `p`.
 
     """
-    def __init__(self, K, F, minimal_ramification=ZZ(1)):
-
+    def __init__(self, K, F, minimal_ramification=1):
+        minimal_ramification = ZZ(minimal_ramification)
         # print "entering WeakPadicGaloisExtension with"
         # print "F = %s"%F
         # if F is a polynomial, replace it by the list of its irreducible factors


### PR DESCRIPTION
which refuses to build subclasses of magic mocks for some reason. The reason is
not the omission of inherited methods. I guess that it tries to find something
on these classes and then decides not to render them because it (naturally)
find whatever it's looking for on a mock.
Note that sphinx's built-in mocking has the same issue.

Fixes #14.