### PR TITLE
Use official SageMath images for CI and binder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,15 +10,17 @@ test: &test
           sage -tp --initial .
 
 jobs:
-  "sage-8.2rc4":
+  "sage-8.2":
     <<: *test
     docker:
-      # TODO: pin to sagemath/sagemath:8.2 once that has been released for docker
-      - image: saraedum/sagemath:latest
+      - image: sagemath/sagemath:8.2
+  "sage-8.3.beta0":
+    <<: *test
+    docker:
+      - image: sagemath/sagemath:8.3.beta0
   docbuild-sage:
     docker:
-      # TODO: pin to sagemath/sagemath:latest once that has been released for docker
-      - image: saraedum/sagemath:latest
+      - image: sagemath/sagemath:latest
     steps:
       - checkout
       - run:
@@ -46,7 +48,9 @@ workflows:
   version: 2
   test:
     jobs:
-      - sage-8.2rc4
+      # When adding a new stable release of Sage here, make sure to also upgrade the Dockerfile
+      - sage-8.2
+      - sage-8.3.beta0
   doc:
     jobs:
       - docbuild-sage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
 # A Dockerfile for [binder](http://mybinder.readthedocs.io/en/latest/using.html#Dockerfile)
-# TODO: Change this to an official version of sagemath once https://trac.sagemath.org/ticket/24655 has been merged
-FROM saraedum/sagemath:develop
+FROM sagemath/sagemath:8.2
 COPY --chown=sage:sage . .


### PR DESCRIPTION
I did not tag to latest/develop for CI as it is better to check with every
release that things still work by explicitly upgrading these.

We might want to change the tag in the Dockerfile with every major release of
Sage when we checked that everything worked.