### PR TITLE
missing __repr__ method for `AdmissibleModel`

### DIFF
--- a/mclf/semistable_reduction/admissible_reduction.py
+++ b/mclf/semistable_reduction/admissible_reduction.py
@@ -105,9 +105,10 @@ class AdmissibleModel(SemistableModel):
         self._reduction_tree = reduction_tree
 
 
+    def __repr__(self):
+        return "semistable model of %s, with respect to %s"%(self.curve(), self.base_valuation())
+
+
     def original_model_of_curve(self):
         """ Return the original model of the curves. """
         return self._original_model_of_curve
-
-
-   

--- a/mclf/semistable_reduction/semistable_models.py
+++ b/mclf/semistable_reduction/semistable_models.py
@@ -181,7 +181,9 @@ class SemistableModel(SageObject):
         sage: FY.<y> = FX.extension(y^3 - y^2 + x^4 + x + 1)
         sage: Y = SmoothProjectiveCurve(FY)
         sage: YY = SemistableModel(Y, v_5)
-
+        sage: YY
+        semistable model of the smooth projective curve with Function field in y defined by y^3 - y^2 + x^4 + x + 1, with respect to 5-adic valuation
+        
     The degree of `Y` as a cover of the projective line is `4`, which is strictly
     less than `p=5`. Hence `Y` has admissible reduction and we have created an instance
     of the class ``AdmissibleModel``::
@@ -216,12 +218,16 @@ class SemistableModel(SageObject):
             raise NotImplementedError
 
 
+    def __repr__(self):
+        return "semistable model of %s, with respect to %s"%(self.curve(), self.base_valuation())
+
+
     def curve(self):
         """
         Return the curve.
 
         """
-        return self._Y
+        return self._curve
 
 
     def base_field(self):
@@ -229,7 +235,7 @@ class SemistableModel(SageObject):
         Return the base field of this curve.
 
         """
-        self._Y.base_field()
+        self.curve().base_field()
 
 
     def base_valuation(self):
@@ -237,7 +243,7 @@ class SemistableModel(SageObject):
         Return the valuation on the base field of the curve.
 
         """
-        return self._vK
+        return self._base_valuation
 
 
     def reduction_tree(self):

--- a/mclf/semistable_reduction/superp_models.py
+++ b/mclf/semistable_reduction/superp_models.py
@@ -171,7 +171,7 @@ class SuperpModel(SemistableModel):
         assert p == vK.residue_field().characteristic(), "the exponent p must be the residue characteristic of vK"
         assert not p.divides(f.degree()), "the degree of f must be prime to p"
         self._p = p
-        self._vK = vK
+        self._base_valuation = vK
         v0 = GaussValuation(R, vK)
         phi, psi, f1 = v0.monic_integral_model(f)
         # now f1 = phi(f).monic()
@@ -190,20 +190,20 @@ class SuperpModel(SemistableModel):
             self._FX = FX
             self._FY = FY
             Y = SmoothProjectiveCurve(FY)
-            self._Y = Y
+            self._curve = Y
         else:
             self._f = f.monic()
             self._a = vK.domain().one()
             self._FY = Y.function_field()
             self._FX = Y.rational_function_field()
-            self._Y = Y
+            self._curve = Y
         X = BerkovichLine(self._FX, vK)
         self._X = X
 
 
     def __repr__(self):
         return "semistable model of superelliptic curve Y: y^%s = %s over %s, with respect to %s"%(self._p,
-                        self._a*self._f, self._vK.domain(), self._vK)
+                        self._a*self._f, self.base_valuation().domain(), self.base_valuation())
 
 
     def etale_locus(self):
@@ -273,7 +273,7 @@ class SuperpModel(SemistableModel):
             a.append(a[i-1].derivative()/i)
         a = [a[i]/f for i in range(n+1)]
 
-        pi = self._vK.uniformizer()
+        pi = self.base_valuation().uniformizer()
         delta = [ c[pl]**(p-1) * pi**(-p) ]
         delta += [ c[pl]**(i*(p-1)) * a[i]**(-pl*(p-1)) * pi**(-i*p)
                    for i in range(1, n+1) ]
@@ -290,7 +290,7 @@ class SuperpModel(SemistableModel):
                 # if delta[i] is constant, it must not be integral
                 # otherwise we add the whole Berkovich line which is
                 # not an affinoid
-                assert self._vK(delta[i]) < 0, "this is not an affinoid"
+                assert self.base_valuation()(delta[i]) < 0, "this is not an affinoid"
                 # if vK(delta[i]) >= 0 then we add the empty set, i.e
                 # we do nothing
             else:


### PR DESCRIPTION
Along the way, inconsistent naming of secret attributes
(_vK, _Y etc) has been changed in `semistable_models`,
`admissible_reduction` and `superp_models`