### PR TITLE
fix issue 61

### DIFF
--- a/mclf/semistable_reduction/reduction_trees.py
+++ b/mclf/semistable_reduction/reduction_trees.py
@@ -897,7 +897,8 @@ class LowerComponent(ReductionComponent):
         v = self.valuation()
         FY = self.reduction_tree().curve().function_field()
         FYL = base_change_of_function_field(FY, self.base_field())
-        upper_valuations = [FYL.valuation(w) for w in v.mac_lane_approximants(FYL.polynomial())]
+        upper_valuations = [FYL.valuation(w)
+            for w in v.mac_lane_approximants(FYL.polynomial(), require_incomparability=True)]
         return [UpperComponent(self, w) for w in upper_valuations]
 
 


### PR DESCRIPTION
In `reduction_trees.py`, `LowerComponent.upper_components`,
the call of `v.mac_lane_approximants` now has the parameter
`require_incomparability=True`. This seems to fix the problem.

However, one still needs to make sure that this parameter is
enough to guarantee that the approximants are sufficiently
precise to induce the desired function field valuation.