### PR TITLE
gitignore installation files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ notes/
 old_stuff/
 test/
 build/
+
+# ignore installation files
+mclf.egg-info/
+dist


### PR DESCRIPTION
added mclf.egg-info/ and dist/
to .gitignore, see issue #72