### PR TITLE
Run tests and launch binder with Sage 8.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,14 +17,14 @@ jobs:
     <<: *test
     docker:
       - image: sagemath/sagemath:8.2
-  "test-sage-8.3.beta3":
+  "test-sage-8.3":
     <<: *test
     docker:
-      - image: sagemath/sagemath:8.3.beta3
+      - image: sagemath/sagemath:8.3
   coverage:
     working_directory: /home/sage/mclf
     docker:
-      - image: sagemath/sagemath:8.2
+      - image: sagemath/sagemath:8.3
     steps:
       - checkout
       - run:
@@ -138,7 +138,7 @@ workflows:
     jobs:
        # When adding a new stable release of Sage here, make sure to also upgrade the Dockerfile
        - test-sage-8.2
-       - test-sage-8.3.beta3
+       - test-sage-8.3
        - pyflakes
        - coverage
        - docbuild-sage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 # A Dockerfile for [binder](https://mybinder.readthedocs.io/en/latest/using.html#Dockerfile)
-FROM sagemath/sagemath:8.3.beta3
+FROM sagemath/sagemath:8.3
 COPY --chown=sage:sage . .
 RUN sage -python setup.py install


### PR DESCRIPTION
there is no point in testing with outdated betas. We should add the 8.4 betas
once the first one is out.