### PR TITLE
Fix docbuild

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -339,7 +339,7 @@ epub_exclude_files = ['search.html']
 autodoc_default_flags = ["members", "show-inheritance"]
 
 try:
-    import sage
+    import sage.all
 except ImportError:
     from unittest.mock import MagicMock
 


### PR DESCRIPTION
sage is very picky about the order in which modules are imported. I am not
entirely sure what's the problem here, but importing sage.all makes `sage -sh
-c 'make html SPHINXOPTS="-W"'` work.

Fixes #84