### PR TITLE
Replace ^ by **

### DIFF
--- a/mclf/berkovich/affinoid_domain.py
+++ b/mclf/berkovich/affinoid_domain.py
@@ -690,7 +690,7 @@ class AffinoidDomainOnBerkovichLine(SageObject):
         if xi0.is_in_unit_disk():
             xi1 = X.point_from_discoid(phi, Infinity)
         else:
-            xi1 = X.point_from_discoid(phi(1/x)*x^phi.degree())
+            xi1 = X.point_from_discoid(phi(1/x)*x**phi.degree())
         assert U.is_contained_in(xi1), "error: xi1 is not contained in U"
         return xi1
 


### PR DESCRIPTION
In affinoid_domain.py, there was one instance where ^ was used for exponentiation,
instead of **. 