### PR TITLE
Extensive bugfix in berkovich_line

### DIFF
--- a/mclf/berkovich/affinoid_domain.py
+++ b/mclf/berkovich/affinoid_domain.py
@@ -888,7 +888,7 @@ class RationalDomainOnBerkovichLine(AffinoidDomainOnBerkovichLine):
             if xi1_in != xi2_in:
                 # there must be a point between xi1 and xi2 where v(f)=0
                 # which we have to add to the in_list
-                xi3 = xi1._X.find_zero(xi1, xi2, f)
+                xi3 = xi1.berkovich_line().find_zero(xi1, xi2, f)
                 assert xi3.v(f) == 0, "got the wrong value for t!"
                 in_list.append(xi3)
             U = U.add_points(in_list, out_list)

--- a/mclf/berkovich/berkovich_line.py
+++ b/mclf/berkovich/berkovich_line.py
@@ -1829,11 +1829,6 @@ def valuation_from_discoid(vK, f, s):
         a = [v1(c) for c in v.coefficients(f)]
         t = max([(s-a[i])/i for i in range(1,len(a)) ])
         v = v1.augmentation(v.phi(), t)
-        if not v(f)==s:
-            print "f = ", f
-            print "f = s", s
-            print "v = ", v
-            print
         assert v(f) == s
         if v(v.phi()[0]) >= v(v.phi()):
             # the discoid D_v contains 0;

--- a/mclf/semistable_reduction/superp_models.py
+++ b/mclf/semistable_reduction/superp_models.py
@@ -255,7 +255,7 @@ class SuperpModel(SemistableModel):
             sage: YY.etale_locus()
             Elementary affinoid defined by
             v(1/x) >= -5/2
-            v(x + 4) >= 2
+            v(x) >= 2
 
 
     .. NOTE::


### PR DESCRIPTION
The code in berkovich_lines was very
buggy; most problems had to do with
the discoid representation of points,
and the use of valuation on function
field via an automorphism (see issue
#39 and #dde6e90).

These problems should now be solved
(hopefully). I also added several doctest and improved the 
documentation.