### PR TITLE
fix a problem with type V points

### DIFF
--- a/mclf/berkovich/affinoid_domain.py
+++ b/mclf/berkovich/affinoid_domain.py
@@ -668,6 +668,26 @@ class AffinoidDomainOnBerkovichLine(SageObject):
             sage: U.point_close_to_boundary(xi0)
             Point of type I on Berkovich line given by x + 2 = 0
 
+        At the moment, our choice of point close to the boundary is not
+        optimal, as the following example shows: ::
+
+            sage: U = RationalDomainOnBerkovichLine(X, 2/(x^2+x+1))
+            sage: U
+            Affinoid with 1 components:
+            Elementary affinoid defined by
+            v(1/(x^2 + x + 1)) >= -1
+
+            sage: xi0 = U.boundary()[0]
+            sage: U.point_close_to_boundary(xi0)
+            Point of type I on Berkovich line given by x^2 + 3*x + 1 = 0
+
+        The point at infinity is also inside U and 'close to the boundary',
+        and has smaller degree than the point produced above.
+
+        .. TODO::
+
+            Use a better strategie to find a point of minimal degree.
+
         """
         U = self
         T = U._T
@@ -676,6 +696,8 @@ class AffinoidDomainOnBerkovichLine(SageObject):
         x = F.gen()
         T0 = T.find_point(xi0)
         assert T0 != None and T0._is_in_affinoid, "xi0 is not a boundary point"
+        # we only look for point of type I which are larger than xi0
+        # but it may be possibleto find other points with smaller degree
         v0 = xi0.pseudovaluation_on_polynomial_ring()
         Rb = v0.residue_ring()
         psi = Rb.one()
@@ -683,8 +705,8 @@ class AffinoidDomainOnBerkovichLine(SageObject):
             if not T1._is_in_affinoid:
                 eta1 = TypeVPointOnBerkovichLine(xi0, T1.root())
                 psi1 = eta1.minor_valuation().uniformizer()
-                assert psi1.denominator().is_one(), "psi1 is not a polynomial"
-                psi = psi * Rb(psi1.numerator())
+                if psi1.denominator().is_one():
+                    psi = psi * Rb(psi1.numerator())
         phib = irreducible_polynomial_prime_to(psi)
         phi = v0.lift_to_key(phib)
         if xi0.is_in_unit_disk():
@@ -696,7 +718,6 @@ class AffinoidDomainOnBerkovichLine(SageObject):
                 xi1 = X.point_from_discoid(phi(1/x)*x**phi.degree(), Infinity)
         assert U.is_contained_in(xi1), "error: xi1 is not contained in U"
         return xi1
-
 
 
 class ClosedUnitDisk(AffinoidDomainOnBerkovichLine):

--- a/mclf/berkovich/type_V_points.py
+++ b/mclf/berkovich/type_V_points.py
@@ -187,7 +187,6 @@ class TypeVPointOnBerkovichLine(SageObject):
                 phi_pol = v0.equivalence_decomposition(v1.phi())[0][0]
                 # phi_pol is a key polynomial for v_0
                 self._phi_pol = phi_pol
-                phib = normalized_reduction(v0, phi_pol)
                 phi = phi_pol(x)
                 self._phi = phi
                 self._s = xi0.v(phi)
@@ -197,7 +196,6 @@ class TypeVPointOnBerkovichLine(SageObject):
                 # of the closed unit disk
                 phi_pol = v0.equivalence_decomposition(v1.phi())[0][0]
                 self._phi_pol = phi_pol
-                phib = normalized_reduction(v0, phi_pol)
                 phi = phi_pol(1/x)
                 self._phi = phi
                 self._s = xi0.v(phi)
@@ -224,7 +222,7 @@ class TypeVPointOnBerkovichLine(SageObject):
                 self._s = xi0.v(phi)
                 self._type = "contains_unit_disk"
         # we test that the discoid representation is correct.
-        assert not self.is_in_residue_class(xi0), "xi1 must not lie in the residue class!"
+        assert self._v(self._phi)==self._s, "xi1 must not lie in the residue class!"
         assert self.is_in_residue_class(xi1), "xi2 must lie in the residue class!"
 
 
@@ -560,28 +558,3 @@ class TypeVPointOnBerkovichLine(SageObject):
         return v.effective_degree(f)
 
 #--------------------------------------------------------------------------
-
-def normalized_reduction(v, f):
-    r""" Return the normalized reduction of ``f`` with respect to ``v``.
-
-    INPUT:
-
-    - ``v`` -- an inductive valuation on `K[x]`
-    - ``f`` -- an element of `K[x]`
-
-    OUTPUT:
-
-    The normalized reduction of ``f`` with respect to ``v``, defined as follows:
-    let `g\in K[x]` be an equivalence unit for ``v`` such that `v(g)=-v(f)`.
-    Then the *normalized reduction* is defined as the image of `fg` in the residue
-    ring of `v`. The result is only well defined up to multiplication with
-    a constant.
-    THIS IS NOT WELL DEFINED: IN GENERAL, `g` AS ABOVE DOES NOT EXIST!
-    """
-
-    r = v(f)
-    m = abs(r.denominator())
-    fb = v.reduce(f**m*v.equivalence_unit(-m*r))
-    Fb = fb.factor()
-    fb = Fb[0][0]
-    return fb


### PR DESCRIPTION
In some cases, the minor valuation of
a point of type V was defined incorrectly.

Related to this, the function 
point_on_boundary in affinoid_domains
would erronously raise an assertion 
error under some circumstances. 

Both problems have been fixed, the documentation has been clarified, and 
some doctests have been added.