### PR TITLE
Fix bug related to issue #103

### DIFF
--- a/mclf/semistable_reduction/reduction_trees.py
+++ b/mclf/semistable_reduction/reduction_trees.py
@@ -1246,11 +1246,11 @@ def make_function_field(K):
 
     .. NOTE::
 
-    this command seems to be partly superflous by now, because the residue
-    of a valuation is already of type "function field" whenever this makes sense.
-    However, even if `K` is a function field over a finite field, it is not
-    guaranteed that the constant base field is a 'true' finite field, and then
-    it is important to change that.
+        this command seems to be partly superflous by now, because the residue
+        of a valuation is already of type "function field" whenever this makes sense.
+        However, even if `K` is a function field over a finite field, it is not
+        guaranteed that the constant base field is a 'true' finite field, and then
+        it is important to change that.
 
     """
     from mclf.curves.smooth_projective_curves import make_finite_field


### PR DESCRIPTION
With Sage 8.6, residue fields of valuations on function fields are now 
function fields themselves, if this makes sense. However, the constant 
base field may not be a *true* finite field (this is trac:26103). This 
resulted in an error message when applying the method 
``make_function_field``.

Now ``make_function_field`` creates a new function field with the right 
kind of constant base field if the input is already a function field.