### PR TITLE
Drop Support for 8.2 & 8.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,18 +13,30 @@ jobs:
             sage -pip install patchy
             sage -python setup.py install
             sage -tp --long --initial mclf docs
-  "test-sage-8.2":
+  "test-sage-8.4":
     <<: *test
     docker:
-      - image: sagemath/sagemath:8.2
-  "test-sage-8.3":
+      - image: sagemath/sagemath:8.4
+  "test-sage-8.5":
     <<: *test
     docker:
-      - image: sagemath/sagemath:8.3
+      - image: sagemath/sagemath:8.5
+  "test-sage-8.6":
+    <<: *test
+    docker:
+      - image: sagemath/sagemath:8.6
+  "test-sage-8.7":
+    <<: *test
+    docker:
+      - image: sagemath/sagemath:8.7
+  "test-sage-8.8":
+    <<: *test
+    docker:
+      - image: sagemath/sagemath:8.8
   coverage:
     working_directory: /home/sage/mclf
     docker:
-      - image: sagemath/sagemath:8.3
+      - image: sagemath/sagemath:8.8
     steps:
       - checkout
       - run:
@@ -137,8 +149,11 @@ workflows:
   test:
     jobs:
        # When adding a new stable release of Sage here, make sure to also upgrade the Dockerfile
-       - test-sage-8.2
-       - test-sage-8.3
+       - test-sage-8.4
+       - test-sage-8.5
+       - test-sage-8.6
+       - test-sage-8.7
+       - test-sage-8.8
        - pyflakes
        - coverage
        - docbuild-sage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 # A Dockerfile for [binder](https://mybinder.readthedocs.io/en/latest/using.html#Dockerfile)
-FROM sagemath/sagemath:8.3
+FROM sagemath/sagemath:8.8
 COPY --chown=sage:sage . .
 RUN sage -python setup.py install

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This means that we want to know
 At the moment we can do this only in certain special cases, which should
 nevertheless be useful.
 
-If you have at least [Sage 8.2](https://www.sagemath.org/) you can install the
+If you have at least [Sage 8.4](https://www.sagemath.org/) you can install the
 latest version of this package with `sage -pip install --user --upgrade mclf`.
 
 If you can not install Sage on your local machine, you can also click


### PR DESCRIPTION
while things still work, it's probably not worth it to maintain the
differences in doctesting for these old versions of SageMath.