### PR TITLE
Fixed bug in `infimum`

### DIFF
--- a/mclf/berkovich/berkovich_line.py
+++ b/mclf/berkovich/berkovich_line.py
@@ -1832,6 +1832,9 @@ class TypeIIPointOnBerkovichLine(PointOnBerkovichLine):
         if xi1.is_in_unit_disk() != xi2.is_in_unit_disk():
             return X.gauss_point()
         # now the point lie both inside or outside the unit disk
+        # if xi2 is of type I, we have to replace it by a sufficiently good approx.
+        if xi2.type() == "I":
+            xi2 = xi2.approximation(xi1)
         f1, s1 = xi1.discoid()
         f2, s2 = xi2.discoid()
         if not xi1.is_in_unit_disk():


### PR DESCRIPTION
When computing the infimum of two points 
on the Berkovich line one of which is of
type I, it is essential to use an 
approximation which is sufficiently good 
to distinguish it from the other point.