### PR TITLE
Add flag ``check`` to allow f to be divisible by p

### DIFF
--- a/mclf/semistable_reduction/superp_models.py
+++ b/mclf/semistable_reduction/superp_models.py
@@ -284,6 +284,12 @@ class SuperpModel(SemistableModel):
         and of degree prime to `p`. The motivation for this restriction, and its
         result is that the etale locus is contained in the closed unit disk.
 
+        UPDATE: in the current version we test the possibility to remove the
+        requirement that the degree of `f` be prime to `p`. We do this with a
+        'hack', see below. For a clean solution we would need a version of
+        ``valuative_function`` where the domain is allowed to be an *open*
+        discoid.
+
         """
         from mclf.berkovich.piecewise_affine_functions import Domain, Discoid, open_discoid, valuative_function
         from mclf.berkovich.affinoid_domain import UnionOfDomains


### PR DESCRIPTION
If you enter a superelliptic curve

  y^p = f(x),

to ``SemistableModel`` the degree of f has to be
prime to p for mclf to work correctly.

Added a flag ``check`` in ``SuperpModels`` to
override the error message.

The following commits should add the code that
treads this case correctly.